### PR TITLE
ignore SQLite DB access through multiple threads

### DIFF
--- a/smbop/dataset_readers/enc_preproc.py
+++ b/smbop/dataset_readers/enc_preproc.py
@@ -182,8 +182,8 @@ class EncPreproc:
         for db_id, schema in self.schemas.items():
             sqlite_path = Path(self._dataset_path) / db_id / f"{db_id}.sqlite"
             source: sqlite3.Connection
-            with sqlite3.connect(sqlite_path) as source:
-                dest = sqlite3.connect(":memory:")
+            with sqlite3.connect(sqlite_path, check_same_thread=False) as source:
+                dest = sqlite3.connect(":memory:", check_same_thread=False)
                 dest.row_factory = sqlite3.Row
                 source.backup(dest)
             schema.connection = dest


### PR DESCRIPTION
Added check_same_thread=False to lines 185-186 of smbop/dataset_readers/enc_preproc.py so that SQLite3 doesn't complain when the model is run in a multi-threaded context.